### PR TITLE
feat: add breadcrumbs component and localization support

### DIFF
--- a/app/components/ui/Breadcrumbs.vue
+++ b/app/components/ui/Breadcrumbs.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+const { breadcrumbs, jsonLd } = useBreadcrumbs()
+
+// Add JSON-LD to head
+useHead({
+  script: computed(() => 
+    jsonLd.value ? [{
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify(jsonLd.value),
+    }] : []
+  ),
+})
+</script>
+
+<template>
+  <nav 
+    v-if="breadcrumbs.length > 1" 
+    class="text-sm"
+    aria-label="Breadcrumb"
+    itemscope
+    itemtype="https://schema.org/BreadcrumbList"
+  >
+    <ol class="flex items-center space-x-2">
+      <li 
+        v-for="(item, index) in breadcrumbs" 
+        :key="item.path"
+        class="flex items-center"
+        itemprop="itemListElement"
+        itemscope
+        itemtype="https://schema.org/ListItem"
+      >
+        <meta :content="String(index + 1)" itemprop="position">
+        
+        <NuxtLinkLocale
+          v-if="!item.current"
+          :to="item.path"
+          class="text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100 transition-colors"
+          itemprop="item"
+        >
+          <span itemprop="name">{{ item.name }}</span>
+        </NuxtLinkLocale>
+        
+        <span 
+          v-else
+          class="text-neutral-900 dark:text-neutral-100 font-medium"
+          itemprop="name"
+          :aria-current="item.current ? 'page' : undefined"
+        >
+          {{ item.name }}
+        </span>
+
+        <span 
+          v-if="index < breadcrumbs.length - 1"
+          class="mx-2 text-neutral-400"
+          aria-hidden="true"
+        >
+          >
+        </span>
+      </li>
+    </ol>
+  </nav>
+</template>

--- a/app/components/ui/InfoBar.vue
+++ b/app/components/ui/InfoBar.vue
@@ -13,7 +13,11 @@ const disablePath = computed(() => {
     v-if="!disablePath"
     class="z-10 flex flex-col items-center justify-between bg-transparent py-4 text-sm text-inherit font-normal md:(flex-row px-9 py-2 space-y-0) sm:(flex-row px-6 py-2) space-y-2 2xl:px-43 xl:px-30"
   >
-    <UiWeather />
+    <!-- Breadcrumb -->
+    <UiBreadcrumbs />
+    
+    <!-- Weather (fallback when no breadcrumbs) -->
+    <UiWeather v-if="route.path === '/' || route.path === '/ko' || route.path === '/zh'" />
 
     <NuxtTime
       :key="locale"

--- a/app/components/ui/InfoBar.vue
+++ b/app/components/ui/InfoBar.vue
@@ -15,7 +15,6 @@ const disablePath = computed(() => {
   >
     <!-- Breadcrumb -->
     <UiBreadcrumbs />
-    
     <!-- Weather (fallback when no breadcrumbs) -->
     <UiWeather v-if="route.path === '/' || route.path === '/ko' || route.path === '/zh'" />
 

--- a/app/composables/useBreadcrumbs.ts
+++ b/app/composables/useBreadcrumbs.ts
@@ -10,6 +10,8 @@ export function useBreadcrumbs() {
   const localePath = useLocalePath()
   const config = useRuntimeConfig()
 
+  // Move useState outside of computed
+  const currentPost = useState<any>('currentPost', () => null)
   const baseUrl = computed(() => config.public.i18n.baseUrl)
 
   const breadcrumbs = computed<BreadcrumbItem[]>(() => {
@@ -31,7 +33,6 @@ export function useBreadcrumbs() {
 
       // Individual blog post
       if (!path.endsWith('/blog')) {
-        const currentPost = useState<any>('currentPost')
         if (currentPost.value?.title) {
           items.push({
             name: currentPost.value.title,
@@ -90,7 +91,7 @@ export function useBreadcrumbs() {
         '@type': 'ListItem',
         position: index + 1,
         name: item.name,
-        item: `${useRuntimeConfig().public.baseUrl || 'https://xanzhu.com'}${item.path}`,
+        item: `${baseUrl.value || 'https://xanzhu.com'}${item.path}`,
       })),
     }
   })
@@ -100,6 +101,7 @@ export function useBreadcrumbs() {
     jsonLd,
   }
 }
+
 
 
 

--- a/app/composables/useBreadcrumbs.ts
+++ b/app/composables/useBreadcrumbs.ts
@@ -1,0 +1,99 @@
+export interface BreadcrumbItem {
+  name: string
+  path: string
+  current?: boolean
+}
+
+export function useBreadcrumbs() {
+  const { t } = useI18n()
+  const route = useRoute()
+  const localePath = useLocalePath()
+
+  const breadcrumbs = computed<BreadcrumbItem[]>(() => {
+    const path = route.path
+    const items: BreadcrumbItem[] = []
+
+    // Home breadcrumb
+    items.push({
+      name: t('breadcrumbs.home'),
+      path: localePath('/'),
+    })
+
+    // Blog breadcrumbs
+    if (path.includes('/blog')) {
+      items.push({
+        name: t('breadcrumbs.blog'),
+        path: localePath('/blog'),
+      })
+
+      // Individual blog post
+      if (!path.endsWith('/blog')) {
+        const currentPost = useState<any>('currentPost')
+        if (currentPost.value?.title) {
+          items.push({
+            name: currentPost.value.title,
+            path: path,
+            current: true,
+          })
+        }
+      }
+    }
+
+    // Legal pages
+    else if (path.includes('/privacy-policy')) {
+      items.push({
+        name: t('breadcrumbs.privacy'),
+        path: path,
+        current: true,
+      })
+    }
+    else if (path.includes('/terms-of-service')) {
+      items.push({
+        name: t('breadcrumbs.terms'),
+        path: path,
+        current: true,
+      })
+    }
+
+    // Analysis page
+    else if (path.includes('/analysis')) {
+      items.push({
+        name: t('breadcrumbs.analysis'),
+        path: path,
+        current: true,
+      })
+    }
+
+    // Resources page
+    else if (path.includes('/resources')) {
+      items.push({
+        name: t('breadcrumbs.resources'),
+        path: path,
+        current: true,
+      })
+    }
+
+    return items
+  })
+
+  // Generate JSON-LD structured data
+  const jsonLd = computed(() => {
+    if (breadcrumbs.value.length <= 1) return null
+
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: breadcrumbs.value.map((item, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: item.name,
+        item: `https://xanzhu.com${item.path}`,
+      })),
+    }
+  })
+
+  return {
+    breadcrumbs,
+    jsonLd,
+  }
+}

--- a/app/composables/useBreadcrumbs.ts
+++ b/app/composables/useBreadcrumbs.ts
@@ -8,6 +8,9 @@ export function useBreadcrumbs() {
   const { t } = useI18n()
   const route = useRoute()
   const localePath = useLocalePath()
+  const config = useRuntimeConfig()
+
+  const baseUrl = computed(() => config.public.i18n.baseUrl)
 
   const breadcrumbs = computed<BreadcrumbItem[]>(() => {
     const path = route.path
@@ -40,14 +43,14 @@ export function useBreadcrumbs() {
     }
 
     // Legal pages
-    else if (path.includes('/privacy-policy')) {
+    else if (path === localePath('/privacy-policy')) {
       items.push({
         name: t('breadcrumbs.privacy'),
         path: path,
         current: true,
       })
     }
-    else if (path.includes('/terms-of-service')) {
+    else if (path === localePath('/terms-of-service')) {
       items.push({
         name: t('breadcrumbs.terms'),
         path: path,
@@ -56,7 +59,7 @@ export function useBreadcrumbs() {
     }
 
     // Analysis page
-    else if (path.includes('/analysis')) {
+    else if (path === localePath('/analysis')) {
       items.push({
         name: t('breadcrumbs.analysis'),
         path: path,
@@ -65,7 +68,7 @@ export function useBreadcrumbs() {
     }
 
     // Resources page
-    else if (path.includes('/resources')) {
+    else if (path === localePath('/resources')) {
       items.push({
         name: t('breadcrumbs.resources'),
         path: path,
@@ -87,7 +90,7 @@ export function useBreadcrumbs() {
         '@type': 'ListItem',
         position: index + 1,
         name: item.name,
-        item: `https://xanzhu.com${item.path}`,
+        item: `${useRuntimeConfig().public.baseUrl || 'https://xanzhu.com'}${item.path}`,
       })),
     }
   })
@@ -97,3 +100,8 @@ export function useBreadcrumbs() {
     jsonLd,
   }
 }
+
+
+
+
+

--- a/app/pages/blog/[...slug].vue
+++ b/app/pages/blog/[...slug].vue
@@ -1,3 +1,4 @@
+
 <script setup lang="ts">
 import type { PrevNext } from '../../components/Blog/PrevNext.vue'
 
@@ -61,6 +62,12 @@ useSeoMeta({
   ogType: 'article',
   ogImage: seoImage,
 })
+
+// Set current post for breadcrumbs
+const currentPost = useState<any>('currentPost', () => null)
+watch(post, (newPost) => {
+  currentPost.value = newPost
+}, { immediate: true })
 
 // --- Prev / Next
 const { data: prevNext } = await useAsyncData(

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -274,5 +274,13 @@
       "select": "Select Language",
       "switch": "Switch to"
     }
+  },
+  "breadcrumbs": {
+    "home": "Home",
+    "blog": "Blog",
+    "analysis": "Analysis",
+    "resources": "Resources",
+    "privacy": "Privacy Policy",
+    "terms": "Terms of Service"
   }
 }

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -274,5 +274,13 @@
       "select": "언어를 선택하십시오",
       "switch": "전환하십시오"
     }
+  },
+  "breadcrumbs": {
+    "home": "홈",
+    "blog": "블로그",
+    "analysis": "분석",
+    "resources": "리소스",
+    "privacy": "개인정보 처리방침",
+    "terms": "이용약관"
   }
 }

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -274,5 +274,13 @@
       "select": "选择语言",
       "switch": "切换到"
     }
+  },
+  "breadcrumbs": {
+    "home": "首页",
+    "blog": "博客",
+    "analysis": "分析",
+    "resources": "资源",
+    "privacy": "隐私政策",
+    "terms": "服务条款"
   }
 }


### PR DESCRIPTION
breadcrumb navigation system to properly display hierarchical page navigation across the blog and other sections of the site.

### Features
- **Dynamic Breadcrumbs**: Automatically generates breadcrumbs based on current route
- **Blog Integration**: Shows "Home > Blog > [Post Title]" for individual blog posts
- **Internationalization**: Full i18n support for breadcrumb labels
- **SEO Optimized**: Includes JSON-LD structured data for search engines
- **Responsive Design**: Works across all device sizes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced breadcrumb navigation across the app for improved navigation and SEO, including structured data for search engines.
  * Breadcrumbs now display on all pages except the homepage and select language root pages.
* **Localization**
  * Added breadcrumb label translations for English, Korean, and Chinese.
* **Enhancements**
  * Breadcrumb navigation is accessible and adapts based on the current route or blog post.
  * Weather information display is now limited to specific homepage language paths, with breadcrumbs prioritized elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->